### PR TITLE
change readme to recommend dev-master

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The best way to install this library is through [composer](http://getcomposer.or
 ```JSON
 {
     "require": {
-        "tufanbarisyildirim/react-inotify": "1.0.0"
+        "tufanbarisyildirim/react-inotify": "dev-master"
     }
 }
 ```


### PR DESCRIPTION
If you use 1.0.0 it refers to the original package and doesn't pick up any of your changes. Or maybe tag a different version?
